### PR TITLE
Volatility check optimization

### DIFF
--- a/core/monitor/src/main/java/com/webank/wedatasphere/qualitis/util/PassUtil.java
+++ b/core/monitor/src/main/java/com/webank/wedatasphere/qualitis/util/PassUtil.java
@@ -84,7 +84,7 @@ public class PassUtil {
         calendar.add(calendarStepUnit, -1);
         Date lastMonthDate = calendar.getTime();
 
-        return taskResultDao.findAvgByCreateTimeBetweenAndRuleId(ExecutionManagerImpl.PRINT_TIME_FORMAT.format(lastMonthDate), ExecutionManagerImpl.PRINT_TIME_FORMAT.format(nowDate), ruleId);
+        return taskResultDao.findAvgByCreateTimeBetweenAndRuleId(ExecutionManagerImpl.PRINT_DATE_FORMAT.format(lastMonthDate), ExecutionManagerImpl.PRINT_DATE_FORMAT.format(nowDate), ruleId);
     }
 
     private static Boolean moreThanThresholds(Double taskResult, Double compareValue, Double percentage) {

--- a/core/scheduler/src/main/java/com/webank/wedatasphere/qualitis/submitter/impl/ExecutionManagerImpl.java
+++ b/core/scheduler/src/main/java/com/webank/wedatasphere/qualitis/submitter/impl/ExecutionManagerImpl.java
@@ -77,6 +77,7 @@ public class ExecutionManagerImpl implements ExecutionManager {
     private TaskExecuteLimitConfig taskExecuteLimitConfig;
 
     public static final FastDateFormat PRINT_TIME_FORMAT = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
+    public static final FastDateFormat PRINT_DATE_FORMAT = FastDateFormat.getInstance("yyyy-MM-dd");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionManagerImpl.class);
 


### PR DESCRIPTION
Volatility check optimization/波动率校验优化
举日波动率校验为例：如果用粒度到秒去卡平均值的话，昨天校验的值可能都不包含在between and范围内，只留了今天的校验值，随后与今天的校验值进行波动率的比较，明显不符合业务逻辑；优化成天粒度去比较